### PR TITLE
bug fix for  TypeError when loading images

### DIFF
--- a/src/datasets/dataset_celeba.py
+++ b/src/datasets/dataset_celeba.py
@@ -40,8 +40,8 @@ class dataset_celeba(data.Dataset):
     else:
       if np.random.rand(1) > 0.5:
         img = cv2.flip(img, 1)
-      x_offset = np.int32(np.random.randint(0, w - self.image_size + 1, 1))
-      y_offset = np.int32(np.random.randint(0, h - self.image_size + 1, 1))
+      x_offset = np.int32(np.random.randint(0, w - self.image_size + 1, 1))[0]
+      y_offset = np.int32(np.random.randint(0, h - self.image_size + 1, 1))[0]
     crop_img = img[y_offset:(y_offset + self.image_size), x_offset:(x_offset + self.image_size), :]
     return crop_img
 


### PR DESCRIPTION
When running the training as USAGE.md indicated, the program poped such error:

```
self.image_display_iterations=100
self.image_save_iterations=2500
self.snapshot_save_iterations=5000
self.snapshot_prefix='../outputs/unit/celeba/blondhair/blondhair'
self.hyperparameters={'trainer': 'COCOGANTrainer', 'kl_cycle_link_w': 0.1, 'gan_w': 10, 'll_cycle_link_w': 100, 'batch_size': 1, 'll_dire
ct_link_w': 100, 'lr': 0.0001, 'kl_direct_link_w': 0.1, 'max_iterations': 2000000, 'gen': {'ch': 64, 'name': 'COCOResGen2', 'n_gen_front_
blk': 3, 'n_enc_front_blk': 3, 'input_dim_a': 3, 'n_enc_shared_blk': 1, 'input_dim_b': 3, 'n_gen_res_blk': 3, 'n_enc_res_blk': 3, 'n_gen_
shared_blk': 1}, 'dis': {'n_front_layer': 2, 'n_shared_layer': 4, 'ch': 64, 'name': 'COCOSharedDis', 'input_dim_a': 3, 'input_dim_b': 3}}
self.datasets={'train_a': {'channels': 3, 'scale': 1.0, 'class_name': 'dataset_celeba', 'folder': 'img_align_crop_resize_celeba/', 'crop_
image_size': 128, 'root': '../datasets/celeba/', 'list_name': 'lists/Blond_Hair_ON.txt'}, 'train_b': {'channels': 3, 'scale': 1.0, 'class
_name': 'dataset_celeba', 'folder': 'img_align_crop_resize_celeba/', 'crop_image_size': 128, 'root': '../datasets/celeba/', 'list_name': 
'lists/Blond_Hair_OFF.txt'}}
self.display=1
dataset=dataset_celeba(conf)
dataset=dataset_celeba(conf)
Traceback (most recent call last):
  File "cocogan_train.py", line 84, in <module>
    main(sys.argv)
  File "cocogan_train.py", line 52, in main
    for it, (images_a, images_b) in enumerate(itertools.izip(train_loader_a,train_loader_b)):
  File "/root/anaconda2/lib/python2.7/site-packages/torch/utils/data/dataloader.py", line 201, in __next__
    return self._process_next_batch(batch)
  File "/root/anaconda2/lib/python2.7/site-packages/torch/utils/data/dataloader.py", line 221, in _process_next_batch
    raise batch.exc_type(batch.exc_msg)
TypeError: Traceback (most recent call last):
  File "/root/anaconda2/lib/python2.7/site-packages/torch/utils/data/dataloader.py", line 40, in _worker_loop
    samples = collate_fn([dataset[i] for i in batch_indices])
  File "/root/unit/UNIT/src/datasets/dataset_celeba.py", line 28, in __getitem__
    crop_img = self._load_one_image(self.images[index])
  File "/root/unit/UNIT/src/datasets/dataset_celeba.py", line 45, in _load_one_image
    crop_img = img[y_offset:(y_offset + self.image_size), x_offset:(x_offset + self.image_size), :]
TypeError: only integer scalar arrays can be converted to a scalar index
```


After debugging I located the problem, the code "np.int32(np.random.randint(0, h - self.image_size + 1, 1))" returns an array, not an int value, so appending '[0]' may convert it to an int value, which is expected by the "crop_img = img[..." line.